### PR TITLE
Fix missing products.json file for products-mock request

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY tsconfig*.json ./
 COPY package*.json ./
 RUN npm install
+COPY nest-cli.json ./
 COPY src/ src/
 RUN npm run build
 


### PR DESCRIPTION
Assets haven't been copied to the backend service if deploy the entire stack in docker.

Before:
![image](https://github.com/sskorol/aqa-playground/assets/8956849/b6d4c29e-53be-4181-a756-d1fa5a537fbe)
<img width="1286" alt="image" src="https://github.com/sskorol/aqa-playground/assets/8956849/6cc981d2-189b-4899-9d41-5ef159a4d3c8">
<img width="1215" alt="image" src="https://github.com/sskorol/aqa-playground/assets/8956849/fdfc2e5e-f424-4672-ac40-21f6fe53c2b0">

After:

<img width="1356" alt="image" src="https://github.com/sskorol/aqa-playground/assets/8956849/69fe1d46-e46c-468a-807c-7995653691b5">

![Screenshot 2023-10-05 at 19 13 51](https://github.com/sskorol/aqa-playground/assets/8956849/ad46183c-7a1c-4eee-b2d8-dbb4db1cadb6)

